### PR TITLE
For large files created by the removal of the cycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,9 @@ const dbfStream = (path, encoding = 'utf-8') => {
     stream.header.listOfFields = getListOfFields(readStream, stream.header.bytesOfHeader);
     stream.emit('header', stream.header);
   });
-
+  
+  readStream.once('end', () => stream.push(null));
+  
   let numOfRecord = 1;   //row number numOfRecord
   stream._read = () => {
     readStream.on('readable', function onData() {
@@ -136,11 +138,6 @@ const dbfStream = (path, encoding = 'utf-8') => {
       }
 
       readStream.removeListener('readable', onData);
-    });
-
-    readStream.on('end', function onEnd() {
-      stream.push(null);
-      readStream.removeListener('end', onEnd);
     });
   };
 


### PR DESCRIPTION
Method "_read" is called for each record.
This led to the creation of a plurality of subscriber events "end"