### PR TITLE
accept readableStream as input in addition to file

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const iconv = require('iconv-lite');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 const Readable = require('stream').Readable;
+const isStream = require('is-stream');
 
 const fileTypes = {
   2: 'FoxBASE',
@@ -109,11 +110,13 @@ const convertToObject = (data, ListOfFields, encoding, numOfRecord) => {
   return row;
 };
 
-const dbfStream = (path, encoding = 'utf-8') => {
+const dbfStream = (source, encoding = 'utf-8') => {
   const opt = { objectMode: true };
   util.inherits(Readable, EventEmitter);
   const stream = new Readable(opt);
-  const readStream = fs.createReadStream(path);
+
+  // if source is already a readableStream, use it, otherwise treat as a filename
+  const readStream = isStream.readable(source) ? source : fs.createReadStream(source);
 
   readStream._maxListeners = Infinity;
   //read file header first

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/MichaelQQ/dbfstream#readme",
   "dependencies": {
-    "iconv-lite": "^0.4.13"
+    "iconv-lite": "^0.4.13",
+    "is-stream": "^1.1.0"
   },
   "devDependencies": {
     "babel-tape-runner": "^2.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const dbfstream = require('../index');
 const test = require('tape').test;
 const deepFreeze = require('deep-freeze');
+const fs = require('fs');
 
 const testDbfstrea = t => {
   const dbf = dbfstream(__dirname + '/test.dbf', 'utf-8');
@@ -90,3 +91,95 @@ const testDbfstrea = t => {
   });
 };
 test('Test stream based dbf file reader', testDbfstrea);
+
+test('injected stream should be considered a data source', t => {
+  const readableStream = fs.createReadStream(__dirname + '/test.dbf');
+  const dbf = dbfstream(readableStream, 'utf-8');
+
+  const actualData = [];
+
+  dbf.on('header', data => {
+    const expectHeader = {
+    type: 'FoxBASE+/Dbase III plus, no memo',
+    dateUpdated: new Date(1916, 5, 25),
+    numberOfRecords: 5,
+    bytesOfHeader: 129,
+    LengthPerRecord: 26,
+    listOfFields:
+     [
+       {
+         name: 'NAME',
+         type: 'C',
+         displacement: 0,
+         length: 7,
+         decimalPlaces: 0,
+         flag: 0
+       },
+       {
+         name: 'BIRTHDAY',
+         type: 'D',
+         displacement: 0,
+         length: 8,
+         decimalPlaces: 0,
+         flag: 0
+       },
+       {
+         name: 'CELL',
+         type: 'C',
+         displacement: 0,
+         length: 10,
+         decimalPlaces: 0,
+         flag: 0
+       }
+     ]
+   };
+    const actual = data;
+
+    deepFreeze(expectHeader);
+    deepFreeze(actual);
+
+    t.deepEqual(actual, expectHeader, 'must return the file info object');
+  });
+  dbf.on('data', data => {
+    if (!data['@deleted']) {
+      actualData.push(data);
+    }
+  });
+  dbf.on('end', data => {
+    const expectData = [
+      { '@numOfRecord': 1,
+        '@deleted': false,
+        NAME: 'Peter',
+        BIRTHDAY: '20160909',
+        CELL: '0912345678' },
+      { '@numOfRecord': 2,
+        '@deleted': false,
+        NAME: 'Mary',
+        BIRTHDAY: '20160520',
+        CELL: '0922345678' },
+      { '@numOfRecord': 3,
+        '@deleted': false,
+        NAME: 'Michael',
+        BIRTHDAY: '20160808',
+        CELL: '0932345678' },
+      { '@numOfRecord': 4,
+        '@deleted': false,
+        NAME: 'Curry',
+        BIRTHDAY: '20161010',
+        CELL: '0942345678' },
+      { '@numOfRecord': 5,
+        '@deleted': false,
+        NAME: 'James',
+        BIRTHDAY: '20161225',
+        CELL: '0911111111' },
+      ];
+
+    deepFreeze(expectData);
+    deepFreeze(actualData);
+
+    t.deepEqual(actualData, expectData, 'must return all data objects');
+    t.end();
+
+  });
+
+});


### PR DESCRIPTION
This change allows a readableStream to be input as well as a filename which is helpful when piping (with tests!)  Hopefully the [is-stream module](https://www.npmjs.com/package/is-stream) inclusion is okay, it's far more thorough than duck typing.  