### PR TITLE
emit error when there are insufficient header bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ dbf.on('data', (data) => {
 });
 ```
 
+### get dbf file error
+
+```js
+dbf.on('error', (err) => {
+  console.log(err);
+});
+```
+
+* Due to how the parser is written, currently the only condition that emits an error is insufficient bytes in the header.  
+
 ### dbf file stream end:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -137,16 +137,20 @@ const dbfStream = (source, encoding = 'utf-8') => {
     catch (err) {
       stream.emit('error', err);
     }
+
   });
 
   readStream.once('end', () => stream.push(null));
 
   let numOfRecord = 1;   //row number numOfRecord
+
   stream._read = () => {
     readStream.on('readable', function onData() {
-      let chunk;
-      while (null !== (chunk = readStream.read(stream.header.LengthPerRecord))) {
-        stream.push(convertToObject(chunk, stream.header.listOfFields, encoding, numOfRecord++));
+      if (stream.header) {
+        let chunk;
+        while (null !== (chunk = readStream.read(stream.header.LengthPerRecord))) {
+          stream.push(convertToObject(chunk, stream.header.listOfFields, encoding, numOfRecord++));
+        }
       }
 
       readStream.removeListener('readable', onData);

--- a/index.js
+++ b/index.js
@@ -37,6 +37,11 @@ const parseDate = (buffer) => new Date(
 // 30 - 31: Reserved, contains 0x00
 const getHeader = (readStream) => {
   const buffer = readStream.read(32);
+
+  if (buffer.length < 32) {
+    throw `Unable to parse first 32 bytes from header, found ${buffer.length} byte(s)`;
+  }
+
   return {
     type: parseFileType(buffer.slice(0, 1)),
     dateUpdated: parseDate(buffer.slice(1, 4)),
@@ -121,17 +126,18 @@ const dbfStream = (source, encoding = 'utf-8') => {
   readStream._maxListeners = Infinity;
   //read file header first
   readStream.once('readable', () => {
-    stream.header = getHeader(readStream);
+    try {
+      stream.header = getHeader(readStream);
+      stream.header.listOfFields = getListOfFields(readStream, stream.header.bytesOfHeader);
+      stream.emit('header', stream.header);
+    }
+    catch (err) {
+      stream.emit('error', err);
+    }
   });
 
-  //read Descriptor Array
-  readStream.once('readable', () => {
-    stream.header.listOfFields = getListOfFields(readStream, stream.header.bytesOfHeader);
-    stream.emit('header', stream.header);
-  });
-  
   readStream.once('end', () => stream.push(null));
-  
+
   let numOfRecord = 1;   //row number numOfRecord
   stream._read = () => {
     readStream.on('readable', function onData() {

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ const parseDate = (buffer) => new Date(
 const getHeader = (readStream) => {
   const buffer = readStream.read(32);
 
+  if (!buffer) {
+    throw `Unable to parse first 32 bytes from null header`;
+  }
   if (buffer.length < 32) {
     throw `Unable to parse first 32 bytes from header, found ${buffer.length} byte(s)`;
   }

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,27 @@ test('injected stream should be considered a data source', t => {
 
 test('insufficient header bytes should emit error', t => {
   // use t.plan to show that the errors were actually emitted and handled
+  t.plan(1);
+
+  const readableStream = new Duplex();
+  readableStream.push(null);
+
+  const dbf = dbfstream(readableStream, 'utf-8');
+
+  dbf.on('error', err => {
+    t.equals(err, `Unable to parse first 32 bytes from null header`);
+  });
+  dbf.on('header', actualHeader => {
+    t.fail('no header should have been returned');
+  });
+  dbf.on('data', data => {
+    t.fail('no record should have been found');
+  });
+
+});
+
+test('insufficient header bytes should emit error', t => {
+  // use t.plan to show that the errors were actually emitted and handled
   t.plan(2);
 
   // min and max number of bytes for invalid header

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,8 @@ const dbfstream = require('../index');
 const test = require('tape').test;
 const deepFreeze = require('deep-freeze');
 const fs = require('fs');
+const Duplex = require('stream').Duplex;
+const Writable = require('stream').Writable;
 
 const testDbfstrea = t => {
   const dbf = dbfstream(__dirname + '/test.dbf', 'utf-8');
@@ -183,3 +185,103 @@ test('injected stream should be considered a data source', t => {
   });
 
 });
+
+test('insufficient header bytes should emit error', t => {
+  // use t.plan to show that the errors were actually emitted and handled
+  t.plan(2);
+
+  // min and max number of bytes for invalid header
+  [1, 31].forEach(headerByteCount => {
+    const buffer = Buffer.alloc(headerByteCount);
+
+    const readableStream = new Duplex();
+    readableStream.push(buffer);
+    readableStream.push(null);
+
+    const dbf = dbfstream(readableStream, 'utf-8');
+
+    dbf.on('error', err => {
+      t.equals(err, `Unable to parse first 32 bytes from header, found ${headerByteCount} byte(s)`);
+    });
+    dbf.on('header', actualHeader => {
+      t.fail('no header should have been returned');
+    });
+    dbf.on('data', data => {
+      t.fail('no record should have been found');
+    });
+
+  });
+
+});
+
+test('insufficient bytes available for a header field should leave undefined', t => {
+  // use t.plan to show that the header was actually emitted and handled
+  t.plan(1);
+
+  // root header + 1 complete header field + 1 incomplete header field
+  const buffer = Buffer.alloc(67);
+
+  // write out file type
+  buffer.writeUInt8(2, 0);
+  // write out year/month/day
+  buffer.writeUInt8(117, 1);
+  buffer.writeUInt8(6, 2);
+  buffer.writeUInt8(24, 3);
+  // write out number of records
+  buffer.writeUInt32LE(0, 4);
+  // write out bytes of header
+  buffer.writeUInt16LE(buffer.length, 8);
+  // write out length per record
+  buffer.writeUInt16LE(150, 10);
+
+  // write out first header field
+  // first field name
+  buffer.write('field1', 32);
+  // first field type
+  buffer.write('C', 32+11);
+  // first field length
+  buffer.writeInt32LE(37, 32+16);
+
+  // write out incomplete second header field
+  // second field name
+  buffer.write('fie', 64);
+  // this field will be ignored since it contains fewer than 32 bytes
+
+  const readableStream = new Duplex();
+  readableStream.push(buffer);
+  readableStream.push(null);
+
+  const dbf = dbfstream(readableStream, 'utf-8');
+
+  dbf.on('header', actualHeader => {
+    const expectHeader = {
+      type: 'FoxBASE',
+      dateUpdated: new Date(2017, 5, 24),
+      numberOfRecords: 0,
+      bytesOfHeader: 67,
+      LengthPerRecord: 150,
+      listOfFields: [
+        {
+          name: 'field1',
+          type: 'C',
+          displacement: 0,
+          length: 37,
+          decimalPlaces: 0,
+          flag: 0
+        }
+      ]
+    };
+
+    t.deepEqual(actualHeader, expectHeader, 'only 1 header should have been returned');
+
+  });
+
+  dbf.on('error', err => {
+    t.fail('no error should have been emitted');
+  });
+
+  dbf.on('data', data => {
+    t.fail('no record should have been found');
+  });
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@ const test = require('tape').test;
 const deepFreeze = require('deep-freeze');
 const fs = require('fs');
 const Duplex = require('stream').Duplex;
-const Writable = require('stream').Writable;
 
 const testDbfstrea = t => {
   const dbf = dbfstream(__dirname + '/test.dbf', 'utf-8');


### PR DESCRIPTION
The project I'm working on that uses the this module requires the DBF parser to have error handling so this PR introduces support by emitting errors when there are insufficient bytes for the initial header (the first 32 bytes).  I also added a note in the README about the errors handled; the code is so safe regarding buffer slicing and offsets that I was unable to easily trigger more error conditions!  

If you're open to it, I'd love to add more unit tests to handle the various code paths and conditions!

