### PR TITLE
Fix crash with small dbf files

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ const dbfStream = (source, encoding = 'utf-8') => {
   let numOfRecord = 1;   //row number numOfRecord
 
   const onData = () => {
-    if (stream.header) {
+    if (stream.header && stream.header.listOfFields) {
       let chunk;
       while (null !== (chunk = readStream.read(stream.header.LengthPerRecord))) {
         stream.push(convertToObject(chunk, stream.header.listOfFields, encoding, numOfRecord++));
@@ -144,6 +144,7 @@ const dbfStream = (source, encoding = 'utf-8') => {
     }
     catch (err) {
       stream.emit('error', err);
+      stream.push(null);
     }
   });
 


### PR DESCRIPTION
When reading small dbf files, it crashs even it could emit the 'error' event. I got some files created around 1995 with bytesOfHeader always 1025 bytes but the real file readable content size is just about a half of that. 

Adding these guards will always enable the stream not to crash the node process in onData (convertToObject() needs non null stream.header.listOfFields array) event and able to 'end' after emitting 'error' event. 