### PR TITLE
Handle EOF

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ const dbfStream = (source, encoding = 'utf-8') => {
     if (stream.header && stream.header.listOfFields) {
       let chunk;
       while (null !== (chunk = readStream.read(stream.header.LengthPerRecord))) {
+        if (chunk.length === 1 && chunk[0] === 0x1a) continue
         stream.push(convertToObject(chunk, stream.header.listOfFields, encoding, numOfRecord++));
       }
     }


### PR DESCRIPTION
Hello!

This PR adds check for EOF marker. Without this check `dbfstream` puts an extra empty record to the output stream.

https://en.wikipedia.org/wiki/.dbf#File_format_of_Level_5_DOS_dBASE